### PR TITLE
fix: p2sh address send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "dash_spv_apple_bindings"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "cbindgen 0.24.5",
  "dash-spv-coinjoin",

--- a/DashSharedCore.podspec
+++ b/DashSharedCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DashSharedCore'
-  s.version          = '0.5.0'
+  s.version          = '0.5.2'
   s.summary          = 'Dash Core SPV written in Rust'
   s.author           = 'Dash'
   s.description      = "C-bindings for Dash Core SPV that can be used in projects for Apple platform"

--- a/dash-spv-apple-bindings/Cargo.toml
+++ b/dash-spv-apple-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash_spv_apple_bindings"
-version = "0.5.0"
+version = "0.5.2"
 description = "C-bindings for using and interoperating with Dash SPV"
 readme = "README.md"
 edition = "2021"

--- a/dash-spv-masternode-processor/src/util/data_append.rs
+++ b/dash-spv-masternode-processor/src/util/data_append.rs
@@ -134,15 +134,13 @@ impl DataAppend for Vec<u8> /* io::Write */ {
                 [v, data @ ..] if *v == script_map.pubkey => {
                     OP_DUP.into_u8().enc(&mut writer);
                     OP_HASH160.into_u8().enc(&mut writer);
-                    // writer.append_script_push_data(data.to_vec());
                     data.to_vec().append_script_push_data(&mut writer);
                     OP_EQUALVERIFY.into_u8().enc(&mut writer);
                     OP_CHECKSIG.into_u8().enc(&mut writer);
                 },
                 [v, data @ ..] if *v == script_map.script => {
                     OP_HASH160.into_u8().enc(&mut writer);
-                    writer.append_script_push_data(data.to_vec());
-                    // data.to_vec().append_script_push_data(&mut writer);
+                    data.to_vec().append_script_push_data(&mut writer);
                     OP_EQUAL.into_u8().enc(&mut writer);
                 },
                 _ => {}


### PR DESCRIPTION
This pull request includes version updates for the `DashSharedCore` and `dash_spv_apple_bindings` packages, as well as a code fix in the `data_append.rs` file to correct the handling of script data. Below is a summary of the most important changes:

### Version Updates:
* Updated the version of the `DashSharedCore` package from `0.5.0` to `0.5.2` in the `DashSharedCore.podspec` file.
* Updated the version of the `dash_spv_apple_bindings` package from `0.5.0` to `0.5.2` in the `Cargo.toml` file.

### Code Fixes:
* Fixed the handling of script data in the `data_append.rs` file by replacing commented-out code with the correct implementation of `append_script_push_data` for `Vec<u8>`. This ensures that the script data is properly appended to the writer in two cases involving `script_map.pubkey` and `script_map.script`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version numbers for DashSharedCore and dash_spv_apple_bindings packages.
- **Refactor**
  - Improved consistency in data handling within address processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->